### PR TITLE
Add the Sample ontology to the @cotext

### DIFF
--- a/models/jsonld/src/main/java/uk/ac/ebi/biosamples/model/BioSchemasContext.java
+++ b/models/jsonld/src/main/java/uk/ac/ebi/biosamples/model/BioSchemasContext.java
@@ -1,0 +1,43 @@
+package uk.ac.ebi.biosamples.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.ac.ebi.biosamples.service.ContextDeserializer;
+import uk.ac.ebi.biosamples.service.ContextSerializer;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonSerialize(using = ContextSerializer.class)
+@JsonDeserialize(using = ContextDeserializer.class)
+public class BioSchemasContext {
+
+    private final URI schemaOrgContext= URI.create("http://schema.org");
+    private final URI schemaOrgBaseContext = schemaOrgContext;
+    private final Map<String, URI> otherContexts;
+
+    public BioSchemasContext() {
+        this.otherContexts = new HashMap<>();
+    }
+
+    public BioSchemasContext(Map<String, URI> otherContexts) {
+        this.otherContexts = otherContexts;
+    }
+
+    public void addContext(String name, URI id) {
+        this.otherContexts.put(name, id);
+    }
+
+    public URI getSchemaOrgContext() {
+        return schemaOrgContext;
+    }
+
+    public URI getBaseContext() {
+        return schemaOrgBaseContext;
+    }
+
+    public Map<String, URI> getOtherContext() {
+        return otherContexts;
+    }
+}

--- a/models/jsonld/src/main/java/uk/ac/ebi/biosamples/model/JsonLDSample.java
+++ b/models/jsonld/src/main/java/uk/ac/ebi/biosamples/model/JsonLDSample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -14,7 +15,7 @@ import java.util.List;
 public class JsonLDSample implements BioschemasObject {
 
     @JsonProperty("@context")
-    private final String context = "http://schema.org";
+    private final BioSchemasContext sampleContext;
 
     @JsonProperty("@type")
     private final String[] type = {"BioChemEntity", "Sample"};
@@ -30,8 +31,13 @@ public class JsonLDSample implements BioschemasObject {
     @JsonProperty("additionalProperty")
     private List<JsonLDPropertyValue> additionalProperties;
 
-    public String getContext() {
-        return context;
+    public JsonLDSample() {
+        sampleContext = new BioSchemasContext();
+        sampleContext.addContext("Sample", URI.create("http://www.ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/OBI_0000747"));
+    }
+
+    public BioSchemasContext getContext() {
+        return sampleContext;
     }
 
     public String[] getType() {

--- a/models/jsonld/src/main/java/uk/ac/ebi/biosamples/model/JsonLDSample.java
+++ b/models/jsonld/src/main/java/uk/ac/ebi/biosamples/model/JsonLDSample.java
@@ -14,6 +14,8 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class JsonLDSample implements BioschemasObject {
 
+    private final URI sampleOntologyURI =  URI.create("http://purl.obolibrary.org/obo/OBI_0000747");
+
     @JsonProperty("@context")
     private final BioSchemasContext sampleContext;
 
@@ -33,7 +35,7 @@ public class JsonLDSample implements BioschemasObject {
 
     public JsonLDSample() {
         sampleContext = new BioSchemasContext();
-        sampleContext.addContext("Sample", URI.create("http://www.ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/OBI_0000747"));
+        sampleContext.addContext("Sample", sampleOntologyURI);
     }
 
     public BioSchemasContext getContext() {

--- a/models/jsonld/src/main/java/uk/ac/ebi/biosamples/service/ContextDeserializer.java
+++ b/models/jsonld/src/main/java/uk/ac/ebi/biosamples/service/ContextDeserializer.java
@@ -1,0 +1,68 @@
+package uk.ac.ebi.biosamples.service;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import uk.ac.ebi.biosamples.model.BioSchemasContext;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class ContextDeserializer extends StdDeserializer<BioSchemasContext> {
+
+    protected ContextDeserializer() {
+        super(BioSchemasContext.class);
+    }
+
+    protected ContextDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public BioSchemasContext deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        BioSchemasContext context = new BioSchemasContext();
+
+        JsonToken currentToken = jsonParser.getCurrentToken();
+        if (currentToken.equals(JsonToken.START_ARRAY)) {
+            while(jsonParser.hasCurrentToken() && !currentToken.equals(JsonToken.END_ARRAY)) {
+                currentToken = jsonParser.nextToken();
+
+                if (currentToken.equals(JsonToken.VALUE_STRING) && !jsonParser.getValueAsString().equals("http://schema.org")) {
+                    // This is not the link to schema.org we expect to see
+                    throw new JsonParseException(jsonParser, "BioSchemasContext should contain a single schema.org entry string");
+                } else if (currentToken.equals(JsonToken.START_OBJECT)) {
+                    String fieldName = jsonParser.nextFieldName();
+
+                    if (fieldName.equalsIgnoreCase("@base")) {
+                        // Should be the @base context
+
+                        String schemaOrgLink = jsonParser.nextTextValue();
+                        if (!schemaOrgLink.equalsIgnoreCase("http://schema.org")) {
+                            throw new JsonParseException(jsonParser, "BioSchemasContext should contain a @base schema.org entry string");
+                        }
+
+                    } else {
+
+                        currentToken = jsonParser.nextToken();
+                        if (!currentToken.equals(JsonToken.START_OBJECT)) {
+                            throw new JsonParseException(jsonParser, "BioSchemasContext other contexts should be objects");
+                        }
+                        String id = jsonParser.nextFieldName();
+                        if (!id.equalsIgnoreCase("@id")) {
+                            throw new JsonParseException(jsonParser, "BioSchemasContext other context should only contains an @id field");
+                        }
+                        String value = jsonParser.nextTextValue();
+                        context.addContext(fieldName, URI.create(value));
+                    }
+                }
+
+            }
+        } else {
+            throw new JsonParseException(jsonParser, "BioSchemasContext should be an array");
+        }
+        return context;
+    }
+}

--- a/models/jsonld/src/main/java/uk/ac/ebi/biosamples/service/ContextSerializer.java
+++ b/models/jsonld/src/main/java/uk/ac/ebi/biosamples/service/ContextSerializer.java
@@ -1,0 +1,42 @@
+package uk.ac.ebi.biosamples.service;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import uk.ac.ebi.biosamples.model.BioSchemasContext;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+public class ContextSerializer extends StdSerializer<BioSchemasContext> {
+
+    public ContextSerializer() {
+        super(BioSchemasContext.class);
+    }
+
+    @Override
+    public void serialize(BioSchemasContext bioSchemasContext, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartArray();
+
+        // Write the schema.org base namespace
+        jsonGenerator.writeString(bioSchemasContext.getSchemaOrgContext().toString());
+
+        // Write the @base field -> Not sure why this is need, but following UNIPROT convention
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("@base", bioSchemasContext.getBaseContext().toString());
+        jsonGenerator.writeEndObject();
+
+        // Write all the other contexts
+        jsonGenerator.writeStartObject();
+        for(Map.Entry<String, URI> contextEntry: bioSchemasContext.getOtherContext().entrySet()) {
+            jsonGenerator.writeFieldName(contextEntry.getKey());
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField("@id", contextEntry.getValue().toString());
+            jsonGenerator.writeEndObject();
+        }
+        jsonGenerator.writeEndObject();
+
+        jsonGenerator.writeEndArray();
+    }
+}

--- a/models/jsonld/src/test/java/uk/ac/ebi/biosamples/BioschemasContextTest.java
+++ b/models/jsonld/src/test/java/uk/ac/ebi/biosamples/BioschemasContextTest.java
@@ -1,0 +1,56 @@
+package uk.ac.ebi.biosamples.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+//@TestPropertySource(properties = {"spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false","spring.jackson.serialization.WRITE_NULL_MAP_VALUES=false"})
+@TestPropertySource(properties={"spring.jackson.serialization.INDENT_OUTPUT=true"})
+public class BioschemasContextTest {
+
+	private Logger log = LoggerFactory.getLogger(this.getClass());
+
+	private JacksonTester<BioSchemasContext> json;
+	
+	@Test
+	public void testDeserialize() throws Exception {
+        String contextJson = "[" +
+									" \"http://schema.org\", " +
+									" { \"@base\": \"http://schema.org\" }, " +
+									" { \"Sample\": { \"@id\": \"http://www.ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/OBI_0000747\" } } ]";
+
+        BioSchemasContext context = new ObjectMapper()
+				.readerFor(BioSchemasContext.class)
+				.readValue(contextJson);
+
+		// Use JSON path based assertions
+		assertThat(context.getOtherContext().size()).isEqualTo(1);
+		assertThat(context.getOtherContext().containsKey("Sample"));
+		assertThat(context.getOtherContext().get("Sample")).isEqualTo(URI.create("http://www.ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/OBI_0000747"));
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfig {
+
+	}
+
+}

--- a/models/jsonld/src/test/java/uk/ac/ebi/biosamples/BioschemasContextTest.java
+++ b/models/jsonld/src/test/java/uk/ac/ebi/biosamples/BioschemasContextTest.java
@@ -36,7 +36,7 @@ public class BioschemasContextTest {
         String contextJson = "[" +
 									" \"http://schema.org\", " +
 									" { \"@base\": \"http://schema.org\" }, " +
-									" { \"Sample\": { \"@id\": \"http://www.ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/OBI_0000747\" } } ]";
+									" { \"Sample\": { \"@id\": \"http://purl.obolibrary.org/obo/OBI_0000747\" } } ]";
 
         BioSchemasContext context = new ObjectMapper()
 				.readerFor(BioSchemasContext.class)
@@ -45,7 +45,7 @@ public class BioschemasContextTest {
 		// Use JSON path based assertions
 		assertThat(context.getOtherContext().size()).isEqualTo(1);
 		assertThat(context.getOtherContext().containsKey("Sample"));
-		assertThat(context.getOtherContext().get("Sample")).isEqualTo(URI.create("http://www.ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/OBI_0000747"));
+		assertThat(context.getOtherContext().get("Sample")).isEqualTo(URI.create("http://purl.obolibrary.org/obo/OBI_0000747"));
 	}
 
 	@SpringBootConfiguration


### PR DESCRIPTION
This pull request define the context using UNIPROT's example as guidance to include the Sample ontology in the BioSchemas profile

check out the example for reference: https://github.com/BioSchemas/specifications/blob/master/Protein/examples/ProteinEntity-with-context_jsonld.json