### PR TITLE
Updates the links using relative urls

### DIFF
--- a/webapps/core/src/main/asciidoc/guides_submit.adoc
+++ b/webapps/core/src/main/asciidoc/guides_submit.adoc
@@ -12,7 +12,7 @@ We recommend all submissions to BioSamples be made in JSON via our JSON API.
 
 === 2. Legacy SampleTab format
 
-Legacy submissions to BioSamples Database should be in link:st[SampleTab file format]. This is a tab-separated spreadsheet-like text format compatible with popular office tools.
+Legacy submissions to BioSamples Database should be in link:../references/sampletab[SampleTab file format]. This is a tab-separated spreadsheet-like text format compatible with popular office tools.
 
 Once you have a SampleTab file, you can use the +++<a th:href="@{/sampletab/validation}">validation Service</a>+++ to ensure it is correct. This will also apply common corrections and ontology mappings that are used to standardise the data.
 

--- a/webapps/core/src/main/asciidoc/ref_api_overview.adoc
+++ b/webapps/core/src/main/asciidoc/ref_api_overview.adoc
@@ -22,7 +22,7 @@ Link naming follows a consistent pattern.
 * Individual resources are named with the type name, e.g. `sample`
 * Collection resources are named with the plural of the type name in camel case, e.g. `samples`, `curations`, `curationLinks`
 
-For a reference of links available in BioSamples check the corresponding <<ref_api_links.adoc#, Links section>>
+For a reference of links available in BioSamples check the corresponding link:../api/links[Links section]
 
 === Content negotiation for data representation
 

--- a/webapps/core/src/main/asciidoc/ref_api_root.adoc
+++ b/webapps/core/src/main/asciidoc/ref_api_root.adoc
@@ -14,4 +14,4 @@ include::{snippets}/get-index/http-response.adoc[]
 //include::{snippets}/get-index/links.adoc[]
 
 
-For all the links available in BioSamples check the <<ref_api_links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links Reference]

--- a/webapps/core/src/main/asciidoc/ref_api_search.adoc
+++ b/webapps/core/src/main/asciidoc/ref_api_search.adoc
@@ -20,7 +20,7 @@ include::{snippets}/get-samples/http-response.adoc[]
 === Links
 //include::{snippets}/get-samples/links.adoc[]
 
-For all the links available in BioSamples check the <<links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links reference]
 
 == Get sample by accession
 `GET` single BioSamples sample resource using its accession.
@@ -34,7 +34,7 @@ include::{snippets}/get-sample/http-response.adoc[]
 === Links
 //include::{snippets}/get-sample/links.adoc[]
 
-For all the links available in BioSamples check the <<links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links reference]
 
 == Get all samples curations
 `GET` all the BioSamples curation resources in a paginated fashion.
@@ -48,7 +48,7 @@ include::{snippets}/get-curations/http-response.adoc[]
 === Links
 //include::{snippets}/get-curations/links.adoc[]
 
-For all the links available in BioSamples check the <<links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links reference]
 
 == Get sample linked curations
 `GET` all the curation associated to a sample
@@ -60,4 +60,4 @@ include::{snippets}/get-sample-curation/http-request.adoc[]
 include::{snippets}/get-sample-curation/http-response.adoc[]
 
 === Links
-For all the links available in BioSamples check the <<links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links reference]

--- a/webapps/core/src/main/asciidoc/ref_api_submit.adoc
+++ b/webapps/core/src/main/asciidoc/ref_api_submit.adoc
@@ -56,7 +56,7 @@ include::{snippets}/post-sample/http-request.adoc[]
 include::{snippets}/post-sample/http-response.adoc[]
 
 === Links
-For all the links available in BioSamples check the <<ref_api_links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links Reference]
 
 == Update sample
 `PUT` a sample to BioSamples
@@ -70,7 +70,7 @@ include::{snippets}/put-sample/http-request.adoc[]
 include::{snippets}/put-sample/http-response.adoc[]
 
 === Links
-For all the links available in BioSamples check the <<ref_api_links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links Reference]
 
 
 == Submit curation object
@@ -83,5 +83,5 @@ include::{snippets}/post-curation/http-request.adoc[]
 include::{snippets}/post-curation/http-response.adoc[]
 
 === Links
-For all the links available in BioSamples check the <<ref_api_links.adoc#, Links reference>>
+For all the links available in BioSamples check the link:../api/links[Links Reference]
 


### PR DESCRIPTION
(cherry picked from commit db23b377d34e44c76c1308317e6891c116d9156c)
This PR should solve some issues we still have with internal documentation links