### PR TITLE
Added escaping of search terms for BSD-1275

### DIFF
--- a/models/solr/src/main/java/uk/ac/ebi/biosamples/solr/service/SolrSampleService.java
+++ b/models/solr/src/main/java/uk/ac/ebi/biosamples/solr/service/SolrSampleService.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -89,8 +90,8 @@ public class SolrSampleService {
 	 */
 	public CursorArrayList<SolrSample> fetchSolrSampleByText(String searchTerm, Collection<Filter> filters, 
 			Collection<String> domains, String cursorMark, int size) {
-
-		Query query = buildQuery(searchTerm, filters, domains);
+        String escapedSearchTerm = searchTerm == null ? null : ClientUtils.escapeQueryChars(searchTerm);
+		Query query = buildQuery(escapedSearchTerm, filters, domains);
 		query.addSort(new Sort("id")); //this must match the field in solr
 		
 		return solrSampleRepository.findByQueryCursorMark(query, cursorMark, size);

--- a/webapps/core/src/main/java/uk/ac/ebi/biosamples/service/FacetService.java
+++ b/webapps/core/src/main/java/uk/ac/ebi/biosamples/service/FacetService.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.biosamples.service;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -32,7 +33,8 @@ public class FacetService {
 		//TODO allow update date range
 
 		long startTime = System.nanoTime();
-		List<Facet> facets = solrFacetService.getFacets(text, filters, domains, facetPageable, facetValuePageable);
+		String escapedText = text == null ? null : ClientUtils.escapeQueryChars(text);
+		List<Facet> facets = solrFacetService.getFacets(escapedText, filters, domains, facetPageable, facetValuePageable);
 		long endTime = System.nanoTime();
 		log.trace("Got solr facets in "+((endTime-startTime)/1000000)+"ms");
 		


### PR DESCRIPTION
I have escaped special characters used in user search terms to avoid solr error. It appears to be working correctly.

Certainly the term "taxon:9606" no longer causes an error and does provide results that look sensible.