### PR TITLE
added actuator and logback-gelf dependencies to maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -61,6 +65,11 @@
 			<groupId>cglib</groupId>
 			<artifactId>cglib</artifactId>
 			<version>2.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>de.siegmar</groupId>
+			<artifactId>logback-gelf</artifactId>
+			<version>1.1.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Hi Luca, I have just added the graylog library and spring actuator to the global pom.xml. I looked at whether I could do this by just changing logging configuration and adding the libraries to the classpath on startup but this is not possible with spring boot apps it needs to be bundled in. So we will need to release everything with this dependency in to be able to get this working.