### PR TITLE
Bsd 1427 long attributres break sample box ui

### DIFF
--- a/models/ga4gh/src/test/resources/phenopacket1.json
+++ b/models/ga4gh/src/test/resources/phenopacket1.json
@@ -50,7 +50,7 @@
             "name":"Experimental Factor Ontology",
             "namespacePrefix":"EFO",
             "url":"http://www.ebi.ac.uk/efo/efo.owl",
-            "version":"2.102"
+            "version":"2.103"
          }
       ]
    }

--- a/models/ga4gh/src/test/resources/phenopacket2.json
+++ b/models/ga4gh/src/test/resources/phenopacket2.json
@@ -57,7 +57,7 @@
             "name":"Experimental Factor Ontology",
             "namespacePrefix":"EFO",
             "url":"http://www.ebi.ac.uk/efo/efo.owl",
-            "version":"2.102"
+            "version":"2.103"
          }
       ]
    }

--- a/models/ga4gh/src/test/resources/phenopacket3.json
+++ b/models/ga4gh/src/test/resources/phenopacket3.json
@@ -70,7 +70,7 @@
             "name":"Experimental Factor Ontology",
             "namespacePrefix":"EFO",
             "url":"http://www.ebi.ac.uk/efo/efo.owl",
-            "version":"2.102"
+            "version":"2.103"
          }
       ]
    }

--- a/webapps/core/src/main/resources/static/css/shield.css
+++ b/webapps/core/src/main/resources/static/css/shield.css
@@ -17,4 +17,5 @@
 .shield .shield__value {
   background-color: #f27e3f;
   margin: 0 2px 0 0;
+  word-break: break-all;
 }

--- a/webapps/core/src/main/resources/static/css/style.css
+++ b/webapps/core/src/main/resources/static/css/style.css
@@ -86,7 +86,7 @@ div#elixir-banner-info { color: white; }
 /* This means a span element within an element with class shield */
 .shield span { padding: 0.2rem 0.4rem; }
 .shield .shield__key { color: #444; margin: 0 0 0 2px; }
-.shield .shield__value { color: #f27e3f; margin: 0 2px 0 0; }
+.shield .shield__value { color: #f27e3f; margin: 0 2px 0 0; word-break: break-all; }
 
 /* DOCS */
 pre.nowrap {


### PR DESCRIPTION
Long attributes in the sample box break the UI

https://www.ebi.ac.uk/biosamples/samples?text=GSB-7034 
This page layout is broken because some of the attributes are too long to be splitted.