### PR TITLE
Bsd 1430 submit tab hyperlink not working

### DIFF
--- a/utils/webapp/pom.xml
+++ b/utils/webapp/pom.xml
@@ -32,5 +32,10 @@
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-jaxb-annotations</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>uk.ac.ebi.biosamples</groupId>
+			<artifactId>properties</artifactId>
+			<version>4.1.10-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/utils/webapp/pom.xml
+++ b/utils/webapp/pom.xml
@@ -18,6 +18,11 @@
 			<artifactId>models-core</artifactId>
 			<version>4.1.10-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>uk.ac.ebi.biosamples</groupId>
+			<artifactId>properties</artifactId>
+			<version>4.1.10-SNAPSHOT</version>
+		</dependency>
 		<!-- make xml serialization possible -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -31,11 +36,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-jaxb-annotations</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>uk.ac.ebi.biosamples</groupId>
-			<artifactId>properties</artifactId>
-			<version>4.1.10-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/utils/webapp/src/main/java/uk/ac/ebi/biosamples/attributes/ModelAttributeControllerAdvice.java
+++ b/utils/webapp/src/main/java/uk/ac/ebi/biosamples/attributes/ModelAttributeControllerAdvice.java
@@ -1,0 +1,22 @@
+package uk.ac.ebi.biosamples.attributes;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import uk.ac.ebi.biosamples.BioSamplesProperties;
+
+import java.net.URI;
+
+@ControllerAdvice
+public class ModelAttributeControllerAdvice {
+
+    private final BioSamplesProperties bioSamplesProperties;
+
+    public ModelAttributeControllerAdvice(BioSamplesProperties bioSamplesProperties) {
+        this.bioSamplesProperties = bioSamplesProperties;
+    }
+
+    @ModelAttribute("sampletabUrl")
+    public URI addLink() {
+        return bioSamplesProperties.getBiosamplesWebappSampletabUri();
+    }
+}

--- a/utils/webapp/src/main/java/uk/ac/ebi/biosamples/exception/GeneralExceptionControllerAdvice.java
+++ b/utils/webapp/src/main/java/uk/ac/ebi/biosamples/exception/GeneralExceptionControllerAdvice.java
@@ -1,0 +1,38 @@
+package uk.ac.ebi.biosamples.exception;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.ac.ebi.biosamples.BioSamplesProperties;
+
+@ControllerAdvice
+public class GeneralExceptionControllerAdvice extends ResponseEntityExceptionHandler {
+
+    private final BioSamplesProperties bioSamplesProperties;
+
+    public GeneralExceptionControllerAdvice(BioSamplesProperties bioSamplesProperties) {
+        this.bioSamplesProperties = bioSamplesProperties;
+    }
+
+    @ExceptionHandler(value = {Exception.class})
+    protected ModelAndView handleConflict(Exception exception, WebRequest request) throws Exception {
+        // If the exception is annotated with @ResponseStatus rethrow it and let the framework handle it
+        if (AnnotationUtils.findAnnotation(exception.getClass(), ResponseStatus.class) != null) {
+            throw exception;
+        }
+
+        // Otherwise setup and send the user to a default error-view.
+        ModelAndView mav = new ModelAndView();
+        mav.addObject("exception", exception);
+        mav.addObject("status", "Failed to process the request");
+        mav.addObject("error", exception.getMessage());
+        //todo setup a default error view
+        mav.setViewName("error/4xx");
+        mav.addObject("sampletabUrl", bioSamplesProperties.getBiosamplesWebappSampletabUri());
+        return mav;
+    }
+}

--- a/webapps/core/src/main/java/uk/ac/ebi/biosamples/controller/SampleHtmlController.java
+++ b/webapps/core/src/main/java/uk/ac/ebi/biosamples/controller/SampleHtmlController.java
@@ -67,11 +67,6 @@ public class SampleHtmlController {
 		this.bioSamplesProperties = bioSamplesProperties;
 	}
 
-	//TODO: Convert this to use ControllerAdvice
-	@ModelAttribute
-	public void addCoreLink(Model model) {
-		model.addAttribute("sampletabUrl", bioSamplesProperties.getBiosamplesWebappSampletabUri());
-	}
 
 	@GetMapping(value = "/")
 	public String index(Model model) {


### PR DESCRIPTION
SampleTab link does not appear in the error model of the webapps-core. Instead of passing SampleTab URL at each controller, controller advised can be used to inject it. Added a general error handler  to customise error handling.