### PR TITLE
Bsd 1421 suppressed samples

### DIFF
--- a/agents/solr/pom.xml
+++ b/agents/solr/pom.xml
@@ -48,8 +48,13 @@
 			<!-- <version>${httpclient.version}</version> -->
 			<version>4.5.3</version>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
  	<build>
  		<plugins>

--- a/agents/solr/src/main/java/uk/ac/ebi/biosamples/solr/MessageHandlerSolr.java
+++ b/agents/solr/src/main/java/uk/ac/ebi/biosamples/solr/MessageHandlerSolr.java
@@ -1,80 +1,95 @@
 package uk.ac.ebi.biosamples.solr;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.ac.ebi.biosamples.MessageContent;
 import uk.ac.ebi.biosamples.Messaging;
+import uk.ac.ebi.biosamples.model.Attribute;
 import uk.ac.ebi.biosamples.model.Sample;
 import uk.ac.ebi.biosamples.ols.OlsProcessor;
 import uk.ac.ebi.biosamples.solr.model.SolrSample;
 import uk.ac.ebi.biosamples.solr.repo.SolrSampleRepository;
 import uk.ac.ebi.biosamples.solr.service.SampleToSolrSampleConverter;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
 @Service
 public class MessageHandlerSolr {
-	private Logger log = LoggerFactory.getLogger(this.getClass());
-	
-	@Autowired
-	private SolrSampleRepository repository;
-	
-	@Autowired
-	private SampleToSolrSampleConverter sampleToSolrSampleConverter;
-	
-	@Autowired
-	private OlsProcessor olsProcessor;
-		
-	@RabbitListener(queues = Messaging.queueToBeIndexedSolr)
-	public void handle(MessageContent messageContent) throws Exception {
-		
-		if (messageContent.getSample() == null) {
-			log.warn("Recieved message without sample");
-			return;
-		}
 
-		Sample sample = messageContent.getSample();
-		handleSample(sample, messageContent.getCreationTime());
-		for (Sample related : messageContent.getRelated()) {
-			handleSample(related, messageContent.getCreationTime());
-		}
-		
-	}
-	
-	private void handleSample(Sample sample, String modifiedTime) {
-		SolrSample solrSample = sampleToSolrSampleConverter.convert(sample);
-		//add the modified time to the solrSample
-		String indexedTime = ZonedDateTime.now(ZoneOffset.UTC)
-				//.format(DateTimeFormatter.ofPattern("yyyy-mm-dd'T'HH:mm:ss.SSSX"));
-				.format(DateTimeFormatter.ISO_INSTANT);
-		
-		solrSample = SolrSample.build(solrSample.getName(), solrSample.getAccession(), solrSample.getDomain(), 
-				solrSample.getRelease(), solrSample.getUpdate(),
-				modifiedTime, indexedTime, 
-				solrSample.getAttributeValues(), solrSample.getAttributeIris(), solrSample.getAttributeUnits(), 
-				solrSample.getOutgoingRelationships(), solrSample.getIncomingRelationships(), 
-				solrSample.getExternalReferencesData(), solrSample.getKeywords());
-		
-		//expand ontology terms from OLS
-		for (List<String> iris : solrSample.getAttributeIris().values()) {
-			for (String iri : iris) {
-				solrSample.getKeywords().addAll(olsProcessor.ancestorsAndSynonyms("efo", iri));
-				solrSample.getKeywords().addAll(olsProcessor.ancestorsAndSynonyms("NCBITaxon", iri));
-			}
-		}
-		
-		//TODO expand by following relationships
-		
-		solrSample = repository.saveWithoutCommit(solrSample);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageHandlerSolr.class);
 
-		log.trace("Handed "+sample.getAccession());
-		
-	}
+    @Autowired
+    private SolrSampleRepository repository;
+
+    @Autowired
+    private SampleToSolrSampleConverter sampleToSolrSampleConverter;
+
+    @Autowired
+    private OlsProcessor olsProcessor;
+
+    @RabbitListener(queues = Messaging.queueToBeIndexedSolr)
+    public void handle(MessageContent messageContent) throws Exception {
+
+        if (messageContent.getSample() == null) {
+            LOGGER.warn("Recieved message without sample");
+            return;
+        }
+
+        Sample sample = messageContent.getSample();
+        handleSample(sample, messageContent.getCreationTime());
+        for (Sample related : messageContent.getRelated()) {
+            handleSample(related, messageContent.getCreationTime());
+        }
+
+    }
+
+    private void handleSample(Sample sample, String modifiedTime) {
+        if (isIndexingCandidate(sample)) {
+            SolrSample solrSample = sampleToSolrSampleConverter.convert(sample);
+            //add the modified time to the solrSample
+            String indexedTime = ZonedDateTime.now(ZoneOffset.UTC)
+                    //.format(DateTimeFormatter.ofPattern("yyyy-mm-dd'T'HH:mm:ss.SSSX"));
+                    .format(DateTimeFormatter.ISO_INSTANT);
+
+            solrSample = SolrSample.build(solrSample.getName(), solrSample.getAccession(), solrSample.getDomain(),
+                    solrSample.getRelease(), solrSample.getUpdate(),
+                    modifiedTime, indexedTime,
+                    solrSample.getAttributeValues(), solrSample.getAttributeIris(), solrSample.getAttributeUnits(),
+                    solrSample.getOutgoingRelationships(), solrSample.getIncomingRelationships(),
+                    solrSample.getExternalReferencesData(), solrSample.getKeywords());
+
+            //expand ontology terms from OLS
+            for (List<String> iris : solrSample.getAttributeIris().values()) {
+                for (String iri : iris) {
+                    solrSample.getKeywords().addAll(olsProcessor.ancestorsAndSynonyms("efo", iri));
+                    solrSample.getKeywords().addAll(olsProcessor.ancestorsAndSynonyms("NCBITaxon", iri));
+                }
+            }
+
+            //TODO expand by following relationships
+
+            solrSample = repository.saveWithoutCommit(solrSample);
+            LOGGER.info(String.format("indexing %s", sample.getAccession()));
+        }
+    }
+
+    static boolean isIndexingCandidate(Sample sample) {
+        for (Attribute attribute : sample.getAttributes()) {
+            if (attribute.getType().equals("INSDC status")) {
+                List<String> publicStatuses = Arrays.asList("public", "live");
+                if (!publicStatuses.contains(attribute.getValue())) {
+                    LOGGER.info(String.format("not indexing %s as INSDC status is not public", sample.getAccession()));
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/agents/solr/src/test/java/uk/ac/ebi/biosamples/solr/MessageHandlerSolrTest.java
+++ b/agents/solr/src/test/java/uk/ac/ebi/biosamples/solr/MessageHandlerSolrTest.java
@@ -17,8 +17,6 @@ import java.util.Set;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
 public class MessageHandlerSolrTest {
 
     @Test

--- a/agents/solr/src/test/java/uk/ac/ebi/biosamples/solr/MessageHandlerSolrTest.java
+++ b/agents/solr/src/test/java/uk/ac/ebi/biosamples/solr/MessageHandlerSolrTest.java
@@ -1,0 +1,60 @@
+package uk.ac.ebi.biosamples.solr;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.ac.ebi.biosamples.model.Attribute;
+import uk.ac.ebi.biosamples.model.Sample;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class MessageHandlerSolrTest {
+
+    @Test
+    public void should_index_public_sample() throws Exception {
+        Attribute attribute = Attribute.build("INSDC status", "public");
+        assertTrue(MessageHandlerSolr.isIndexingCandidate(generateTestSample("public-example", Collections.singletonList(attribute))));
+    }
+
+    @Test
+    public void should_index_live_sample() throws Exception {
+        Attribute attribute = Attribute.build("INSDC status", "live");
+        assertTrue(MessageHandlerSolr.isIndexingCandidate((generateTestSample("live-example", Collections.singletonList(attribute)))));
+    }
+
+    @Test
+    public void should_index_sample_with_no_INSDC_status() throws Exception {
+        assertTrue(MessageHandlerSolr.isIndexingCandidate((generateTestSample("no-example", Collections.EMPTY_LIST))));
+    }
+
+    @Test
+    public void should_not_index_suppressed_sample() throws Exception {
+        Attribute attribute = Attribute.build("INSDC status", "suppressed");
+        assertFalse(MessageHandlerSolr.isIndexingCandidate((generateTestSample("suppressed-example", Collections.singletonList(attribute)))));
+    }
+
+    @Test
+    public void should_not_index_sample_with_unexpected_INSDC_status() throws Exception {
+        Attribute attribute = Attribute.build("INSDC status", "gertgerge");
+        assertFalse(MessageHandlerSolr.isIndexingCandidate((generateTestSample("unexpected-example", Collections.singletonList(attribute)))));
+    }
+
+    private Sample generateTestSample(String accession, List<Attribute> attributes) {
+        Set<Attribute> attributeSet = new HashSet<>();
+        for (Attribute attribute : attributes) {
+            attributeSet.add(attribute);
+        }
+        return Sample.build("", accession, "", Instant.now(), Instant.now(), attributeSet, Collections.emptySet(), Collections.emptySet());
+    }
+}

--- a/models/core/pom.xml
+++ b/models/core/pom.xml
@@ -36,19 +36,6 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-
-		<!-- issue in Spring-boot 1.4.0.RELEASE only -->
-<!-- 		<dependency> -->
-<!-- 			<groupId>com.google.code.gson</groupId> -->
-<!-- 			<artifactId>gson</artifactId> -->
-<!-- 			<scope>test</scope> -->
-<!-- 		</dependency> -->
-<!-- 		<dependency> -->
-<!-- 			<groupId>xmlunit</groupId> -->
-<!-- 			<artifactId>xmlunit</artifactId> -->
-<!-- 			<version>1.4</version> -->
-<!-- 			<scope>test</scope> -->
-<!-- 		</dependency> -->
 		<dependency>
 			<groupId>org.springframework.hateoas</groupId>
 			<artifactId>spring-hateoas</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,14 +141,6 @@
 	</pluginRepositories>
 
 	<distributionManagement>
-		<!-- <repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository> -->
 		<repository>
 			<id>spotnexus</id>
 			<url>https://www.ebi.ac.uk/spot/nexus/repository/maven-releases/</url>
@@ -168,17 +160,13 @@
 					<compilerArgument>-parameters</compilerArgument>
 				</configuration>
 			</plugin>
-			<!-- <plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
-				<extensions>true</extensions>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
 				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+					<ignoreNonCompile>true</ignoreNonCompile>
 				</configuration>
-			</plugin> -->
+			</plugin>
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>

--- a/utils/json/pom.xml
+++ b/utils/json/pom.xml
@@ -4,13 +4,6 @@
 
 	<artifactId>utils-json</artifactId>
 	<packaging>jar</packaging>
-	<dependencies>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.8.9</version>
-		</dependency>
-	</dependencies>
 
 	<parent>
 		<groupId>uk.ac.ebi.biosamples</groupId>


### PR DESCRIPTION
I have added agent solr so that if a sample has an INSDC Status the sample will only be added to the solr index if the value is public or live.

Samples with any other status such as suppressed will not be added but samples without INSDC Status will continue to be added normally.

This will enable us to support suppressed samples.

I have also fixed a security issue github reported regarding an old version of jackson-databind. I have removed the specific dependency so maven will fall back to the default.