### PR TITLE
make mongoSamples as default view

### DIFF
--- a/models/core/src/main/java/uk/ac/ebi/biosamples/model/StaticViewWrapper.java
+++ b/models/core/src/main/java/uk/ac/ebi/biosamples/model/StaticViewWrapper.java
@@ -14,7 +14,7 @@ public class StaticViewWrapper {
         if (domains != null) {
             staticView = StaticView.SAMPLES_DYNAMIC;
         } else if (curationRepo == null || curationRepo.isEmpty()) {
-            staticView = StaticView.SAMPLES_CURATED;
+            staticView = StaticView.SAMPLES_DYNAMIC;
         } else if (SAMPLE_PRIMARY_REPO.equalsIgnoreCase(curationRepo)) {
             staticView = StaticView.SAMPLES_DYNAMIC;
         } else if (SAMPLE_CURATED_REPO.equalsIgnoreCase(curationRepo)) {

--- a/webapps/core/src/main/java/uk/ac/ebi/biosamples/service/SamplePageService.java
+++ b/webapps/core/src/main/java/uk/ac/ebi/biosamples/service/SamplePageService.java
@@ -76,7 +76,7 @@ public class SamplePageService {
 
 		startTime = System.nanoTime();
 		Page<Future<Optional<Sample>>> pageFutureSample;
-		StaticViewWrapper.StaticView staticViews = StaticViewWrapper.getStaticView(domains, curationRepo);
+		StaticViewWrapper.StaticView staticViews = StaticViewWrapper.getStaticView(domains.isEmpty() ? null : domains, curationRepo);
 		pageFutureSample = pageSolrSample.map(ss -> sampleService.fetchAsync(ss.getAccession(), Optional.empty(), staticViews));
 
 		Page<Sample> pageSample = pageFutureSample.map(ss->{
@@ -105,7 +105,7 @@ public class SamplePageService {
 		CursorArrayList<SolrSample> cursorSolrSample =
 				solrSampleService.fetchSolrSampleByText(text, filters, domains, cursorMark, size);
 
-		StaticViewWrapper.StaticView staticViews = StaticViewWrapper.getStaticView(domains, curationRepo);
+		StaticViewWrapper.StaticView staticViews = StaticViewWrapper.getStaticView(domains.isEmpty() ? null : domains, curationRepo);
 		List<Future<Optional<Sample>>> listFutureSample;
 		listFutureSample = cursorSolrSample.stream()
 				.map(s -> sampleService.fetchAsync(s.getAccession(), Optional.empty(), staticViews))


### PR DESCRIPTION
Before reading from the curated_view of samples, we need to populate that collection. Therefore this release will read from mongoSamples collection by default