### PR TITLE
remove verbose log message, index PubMedId

### DIFF
--- a/models/core/src/main/java/uk/ac/ebi/biosamples/service/CurationApplicationService.java
+++ b/models/core/src/main/java/uk/ac/ebi/biosamples/service/CurationApplicationService.java
@@ -77,7 +77,7 @@ public class CurationApplicationService {
 			//we stopped because we didn't apply any curation
 			//therefore we have some curations that can't be applied
 			//this is a warning
-			log.warn("Unapplied curation on "+sample.getAccession());
+			log.debug("Unapplied curation on {}", sample.getAccession());
 		}
 		return sample;
 	}

--- a/models/solr/src/main/java/uk/ac/ebi/biosamples/solr/service/SampleToSolrSampleConverter.java
+++ b/models/solr/src/main/java/uk/ac/ebi/biosamples/solr/service/SampleToSolrSampleConverter.java
@@ -172,7 +172,7 @@ public class SampleToSolrSampleConverter implements Converter<Sample, SolrSample
 		});
 
 		sample.getPublications().forEach(pub -> {
-			keywords.addAll(Arrays.asList(pub.getDoi(), pub.getDoi()));
+			keywords.addAll(Arrays.asList(pub.getDoi(), pub.getPubMedId()));
 		});
 				
 		return SolrSample.build(sample.getName(), sample.getAccession(), sample.getDomain(), 

--- a/utils/mongo/src/main/java/uk/ac/ebi/biosamples/service/CurationReadService.java
+++ b/utils/mongo/src/main/java/uk/ac/ebi/biosamples/service/CurationReadService.java
@@ -163,7 +163,7 @@ public class CurationReadService {
 		}
 
 		if (failedCuration) {
-			log.warn("Unapplied curation on sample: {}", sample.getAccession());
+			log.debug("Unapplied curation on sample: {}", sample.getAccession());
 		}
 
 		return sample;


### PR DESCRIPTION
Remove verbose log message "unapplied curations". This message is not really helpful now.
Index PubMedId. This wasn't indexed because of a bug