### PR TITLE
Curami fails due to empty values

### DIFF
--- a/pipelines/curami/src/main/java/uk/ac/ebi/biosamples/curation/CuramiApplicationRunner.java
+++ b/pipelines/curami/src/main/java/uk/ac/ebi/biosamples/curation/CuramiApplicationRunner.java
@@ -146,7 +146,7 @@ public class CuramiApplicationRunner implements ApplicationRunner {
             while (failedQueue.peek() != null) {
                 fails.add(failedQueue.poll());
             }
-            failures = "Failed files (" + failedQueue.size() + ") " + String.join(" , ", fails);
+            failures = "Failed files (" + fails.size() + ") " + String.join(" , ", fails);
             LOG.warn(failures);
         } else {
             LOG.info("Pipeline completed without any failures");

--- a/pipelines/curami/src/main/java/uk/ac/ebi/biosamples/curation/SampleCuramiCallable.java
+++ b/pipelines/curami/src/main/java/uk/ac/ebi/biosamples/curation/SampleCuramiCallable.java
@@ -12,9 +12,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class SampleCuramiCallable implements Callable<Integer> {
     private static final Logger LOG = LoggerFactory.getLogger(SampleCuramiCallable.class);
+    static final ConcurrentLinkedQueue<String> failedQueue = new ConcurrentLinkedQueue<>();
 
     private final Sample sample;
     private final BioSamplesClient bioSamplesClient;
@@ -31,43 +33,36 @@ public class SampleCuramiCallable implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        List<Curation> curations = getRuleBasedCurations(sample);
-        if (!curations.isEmpty()) {
-            LOG.info("{} curations added for sample {}", curations.size(), sample.getAccession());
+        int appliedCurations = 0;
+        try {
+            List<Curation> curations = getRuleBasedCurations(sample);
+            if (!curations.isEmpty()) {
+                LOG.info("{} curations added for sample {}", curations.size(), sample.getAccession());
+            }
+            appliedCurations = curations.size();
+        } catch (Exception e) {
+            failedQueue.add(sample.getAccession());
+            LOG.error("Failed to add curation on sample: " + sample.getAccession(), e);
         }
-        return curations.size();
+        return appliedCurations;
     }
 
     private List<Curation> getRuleBasedCurations(Sample sample) {
         SortedSet<Attribute> attributes = sample.getAttributes();
         List<Curation> curations = new ArrayList<>();
         for (Attribute a : attributes) {
-            String processedAttribute = getCleanedAttribute(a.getType());
-            if (curationRules.containsKey(processedAttribute)) {
+            //@here ignoring empty values is wrong. This has done as a workaround as pipeline fails if we post empty
+            //values to curation endpoint. Curation endpoint translate empty values as null values and throw an exception.
+            if (curationRules.containsKey(a.getType()) && !a.getValue().isEmpty()) {
                 Curation curation = Curation.build(
                         Attribute.build(a.getType(), a.getValue(), null, a.getIri(), a.getUnit()),
-                        Attribute.build(curationRules.get(processedAttribute), a.getValue(), null, a.getIri(), a.getUnit()));
-                bioSamplesClient.persistCuration(sample.getAccession(), curation, domain);
+                        Attribute.build(curationRules.get(a.getType()), a.getValue(), null, a.getIri(), a.getUnit()));
                 LOG.info("New curation found {}", curation);
+                bioSamplesClient.persistCuration(sample.getAccession(), curation, domain);
                 curations.add(curation);
             }
         }
 
         return curations;
-    }
-
-    //todo add further processing identified in the analysis
-    private String getCleanedAttribute(String attribute) {
-        /*String cleanedAttribute = attribute.toLowerCase();
-        cleanedAttribute = cleanedAttribute.replaceAll("-", " ");
-
-
-        //camel to snake
-        //whitespace around paranthesis
-        //Fancy characters same as python analysis
-        //
-
-        return cleanedAttribute;*/
-        return attribute; // add all transformation as rules
     }
 }


### PR DESCRIPTION
Do not process empty values, add failing samples to a queue to log and send in mail