### PR TITLE
remove bug relating to pipeline-template and mongo

### DIFF
--- a/pipelines/template/src/main/java/uk/ac/ebi/biosamples/template/PipelineTemplateApplicationRunner.java
+++ b/pipelines/template/src/main/java/uk/ac/ebi/biosamples/template/PipelineTemplateApplicationRunner.java
@@ -5,7 +5,7 @@ import uk.ac.ebi.biosamples.PipelineApplicationRunner;
 import uk.ac.ebi.biosamples.PipelineSampleCallable;
 import uk.ac.ebi.biosamples.PipelinesProperties;
 import uk.ac.ebi.biosamples.client.BioSamplesClient;
-import uk.ac.ebi.biosamples.service.AnalyticsService;
+//import uk.ac.ebi.biosamples.service.AnalyticsService;
 
 @Component
 public class PipelineTemplateApplicationRunner extends PipelineApplicationRunner {
@@ -13,9 +13,9 @@ public class PipelineTemplateApplicationRunner extends PipelineApplicationRunner
     private String domain;
 
     public PipelineTemplateApplicationRunner(BioSamplesClient bioSamplesClient,
-                                             PipelinesProperties pipelinesProperties,
-                                             AnalyticsService analyticsService) {
-        super(bioSamplesClient, pipelinesProperties, analyticsService);
+                                             PipelinesProperties pipelinesProperties/*,
+                                             AnalyticsService analyticsService*/) {
+        super(bioSamplesClient, pipelinesProperties/*, analyticsService*/);
     }
 
     @Override

--- a/utils/pipeline/pom.xml
+++ b/utils/pipeline/pom.xml
@@ -35,11 +35,10 @@
 			<artifactId>xmlunit</artifactId>
 			<version>1.4</version>
 		</dependency>
-        <dependency>
-            <groupId>uk.ac.ebi.biosamples</groupId>
-            <artifactId>utils-mongo</artifactId>
-            <version>4.2.6-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>uk.ac.ebi.biosamples</groupId>-->
+<!--            <artifactId>utils-mongo</artifactId>-->
+<!--            <version>4.2.6-SNAPSHOT</version>-->
+<!--        </dependency>-->
     </dependencies>
 </project>

--- a/utils/pipeline/src/main/java/uk/ac/ebi/biosamples/PipelineApplicationRunner.java
+++ b/utils/pipeline/src/main/java/uk/ac/ebi/biosamples/PipelineApplicationRunner.java
@@ -9,7 +9,7 @@ import uk.ac.ebi.biosamples.client.BioSamplesClient;
 import uk.ac.ebi.biosamples.model.PipelineAnalytics;
 import uk.ac.ebi.biosamples.model.Sample;
 import uk.ac.ebi.biosamples.model.filter.Filter;
-import uk.ac.ebi.biosamples.service.AnalyticsService;
+//import uk.ac.ebi.biosamples.service.AnalyticsService;
 import uk.ac.ebi.biosamples.utils.AdaptiveThreadPoolExecutor;
 import uk.ac.ebi.biosamples.utils.ArgUtils;
 import uk.ac.ebi.biosamples.utils.MailSender;
@@ -30,15 +30,15 @@ public abstract class PipelineApplicationRunner implements ApplicationRunner {
 
     protected final BioSamplesClient bioSamplesClient;
     private final PipelinesProperties pipelinesProperties;
-    private final AnalyticsService analyticsService;
+//    private final AnalyticsService analyticsService;
     private final PipelineFutureCallback pipelineFutureCallback;
 
     public PipelineApplicationRunner(BioSamplesClient bioSamplesClient,
-                                     PipelinesProperties pipelinesProperties,
-                                     AnalyticsService analyticsService) {
+                                     PipelinesProperties pipelinesProperties/*,
+                                     AnalyticsService analyticsService*/) {
         this.bioSamplesClient = bioSamplesClient;
         this.pipelinesProperties = pipelinesProperties;
-        this.analyticsService = analyticsService;
+//        this.analyticsService = analyticsService;
         this.pipelineFutureCallback = new PipelineFutureCallback();
     }
 
@@ -82,7 +82,7 @@ public abstract class PipelineApplicationRunner implements ApplicationRunner {
 
             PipelineAnalytics pipelineAnalytics = new PipelineAnalytics(getPipelineName(), startTime, endTime, sampleCount, pipelineFutureCallback.getTotalCount());
             pipelineAnalytics.setDateRange(filters);
-            analyticsService.persistPipelineAnalytics(pipelineAnalytics);
+//            analyticsService.persistPipelineAnalytics(pipelineAnalytics);
 
             MailSender.sendEmail(getPipelineName(), String.join(",", pipelineFutureCallback.getFailedSamples()), pipelineFutureCallback.getFailedSamples().isEmpty());
         }


### PR DESCRIPTION
remove bug relating to pipeline-template and mongo, will add proper solution later. Instead of adding mongo dependency to pipelines we can send it via API.