### PR TITLE
Remove old AAP URLs and improve auth documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,8 +92,16 @@ The API account can be registered at
 https://explore.aai.ebi.ac.uk/registerUser. A detailed instruction about user account and authentication can be
 found on https://www.ebi.ac.uk/biosamples/docs/guides/authentication.
 +
-*Please replace ALL 'https://aai.ebi.ac.uk' in the authentication guide with 'https://explore.aai.ebi.ac.uk'
-to use the local BioSamples API.*
+
+*Above guide shows AAP account details for production usage.
+Please replace all URL references as below to create and authenticate against development server.*
+[cols="1,1"]
+|===
+| Original                  | Replace with
+| https://aai.ebi.ac.uk     | https://explore.aai.ebi.ac.uk
+| https://api.aai.ebi.ac.uk | https://explore.api.aai.ebi.ac.uk
+|===
+
 . Upload first test data 
 +
 [source,sh]

--- a/webapps/core/src/main/asciidoc/guides_authentication.adoc
+++ b/webapps/core/src/main/asciidoc/guides_authentication.adoc
@@ -18,6 +18,15 @@ are and what data you are allowed to access. You present this information to the
 
 The tokens last for 1 hour, so if you have a long running process you may find the token expires.
 
+*Please note that following guide is for authentication against our production system.
+If you are testing in our development server, please replace following URLs.*
+[cols="1,1"]
+|===
+| Original                  | Replace with
+| https://aai.ebi.ac.uk     | https://explore.aai.ebi.ac.uk
+| https://api.aai.ebi.ac.uk | https://explore.api.aai.ebi.ac.uk
+|===
+
 == Creating your account
 
 You can create an account through the https://aai.ebi.ac.uk/registerUser[AAP webpage], or through their API.
@@ -267,7 +276,7 @@ to access the submissions API.
 == Development servers
 
 We use a different copy of the AAP service to secure our test and development servers. If you are working with them,
-rather than the main server, please use this version of AAP: https://explore.aap.tsi.ebi.ac.uk
+rather than the main server, please use this version of AAP: https://explore.api.aai.ebi.ac.uk
 
 
 == Wrapping up


### PR DESCRIPTION
Remove old AAP URLs
Improve doc to make distinction between prod and dev