### PR TITLE
fix:  hardcoded WSL paths and sample listing issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     - schema-store
     volumes:
     - logs:/logs
-    - "/mnt/c/Users/dgupta/secrets:/secrets"
     command:
     - java
     - -jar
@@ -101,7 +100,6 @@ services:
       - rabbitmq
     volumes:
       - logs:/logs
-      - "/mnt/c/Users/dgupta/secrets:/secrets"
     command:
       - java
       - -jar

--- a/webapps/core/src/main/java/uk/ac/ebi/biosamples/service/SamplePageService.java
+++ b/webapps/core/src/main/java/uk/ac/ebi/biosamples/service/SamplePageService.java
@@ -99,11 +99,7 @@ public class SamplePageService {
         pageFutureSample.map(
             ss -> {
               try {
-                if (ss.get().isPresent()) {
-                  return ss.get().get();
-                } else {
-                  return null;
-                }
+                return ss.get().orElse(null);
               } catch (final InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
               }
@@ -143,7 +139,7 @@ public class SamplePageService {
         .map(
             ss -> {
               try {
-                return ss.get().get();
+                return ss.get().orElse(null);
               } catch (final InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
               }


### PR DESCRIPTION
Some fixes for problems I came across when testing the api: 
1.  Hardcoded WSL volume mounts in docker-compose.yml:                                                                                                                                                                                                              Both biosamples-webapps-core and biosamples-webapps-core-v2 mount a system specific "/mnt/c/Users/dgupta/secrets:/secrets". Running docker compose up on any other machine fails immediately. -> removed the hardcoded line, mount secrets should be handled as env vars (or instead override the original compose)                                                                       
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /mnt/c/Users/dgupta/secrets     
(recently added biosamples-search seems to also have the same issue)
    
2.   When Solr and MongoDB get out of sync, for example, after samples are deleted from MongoDB but Solr hasn't been reindexed yet, Solr returns accessions that no longer exist in MongoDB. The Optional is empty, and .get() throws a NoSuchElementException, which gives a 500 Internal Server Error on the biosamples/samples endpoint. SamplePageService fetches sample pages by first querying Solr for accessions, then looking up each accession in MongoDB. The code calls `ss.get().get()` directly without checking isPresent() -> The paginated variant does check isPresent() but still calls .get().get() redundantly. ->  Replace unchecked Optional.get() with orElse(null) to prevent NoSuchElementException